### PR TITLE
[FIX] Use `wp_remote_get`

### DIFF
--- a/block-editor-custom-alignments.php
+++ b/block-editor-custom-alignments.php
@@ -143,9 +143,15 @@ class Block_Editor_Custom_Alignments {
 			return new \stdClass();
 		}
 
-		$theme_json = file_get_contents( trailingslashit( get_stylesheet_directory_uri() ) . 'theme.json' );
+		$response = wp_remote_get( trailingslashit( get_stylesheet_directory_uri() ) . 'theme.json' );
 
-		if ( $theme_json === false ) {
+		if ( is_wp_error( $response ) ) {
+			return new \stdClass();
+		}
+
+		$theme_json = wp_remote_retrieve_body( $response );
+
+		if ( $theme_json === '' ) {
 			return new \stdClass();
 		}
 


### PR DESCRIPTION
## What does this do/fix?

- there were some SSL errors coming from `file_get_contents` so we've updated the function to use `wp_remote_get` instead
