### PR TITLE
Add workaround for environments with BA

### DIFF
--- a/block-editor-custom-alignments.php
+++ b/block-editor-custom-alignments.php
@@ -154,7 +154,7 @@ class Block_Editor_Custom_Alignments {
 		if ( $json_theme_content !== false ) {
 			$json_theme_json = $this->get_json_theme_json( $json_theme_content );
 
-			if ( ! empty( $json_theme_json ) ) {
+			if ( isset( $this->theme_json->settings->_experimentalLayout ) ) {
 				return  $json_theme_json;
 			}
 		}

--- a/block-editor-custom-alignments.php
+++ b/block-editor-custom-alignments.php
@@ -149,6 +149,16 @@ class Block_Editor_Custom_Alignments {
 			return new \stdClass();
 		}
 
+		$json_theme_content = file_get_contents( trailingslashit( get_stylesheet_directory() )  . 'theme.json' );
+
+		if ( $json_theme_content !== false ) {
+			$json_theme_json = $this->get_json_theme_json( $json_theme_content );
+
+			if ( ! empty( $json_theme_json ) ) {
+				return  $json_theme_json;
+			}
+		}
+
 		$response = wp_remote_get( trailingslashit( get_stylesheet_directory_uri() ) . 'theme.json' );
 
 		if ( is_wp_error( $response ) ) {
@@ -157,6 +167,10 @@ class Block_Editor_Custom_Alignments {
 
 		$theme_json = wp_remote_retrieve_body( $response );
 
+		return $this->get_json_theme_json( $theme_json );
+	}
+
+	private function get_json_theme_json( string $theme_json = '' ): object {
 		if ( $theme_json === '' ) {
 			return new \stdClass();
 		}

--- a/block-editor-custom-alignments.php
+++ b/block-editor-custom-alignments.php
@@ -154,7 +154,7 @@ class Block_Editor_Custom_Alignments {
 		if ( $json_theme_content !== false ) {
 			$json_theme_json = $this->get_json_theme_json( $json_theme_content );
 
-			if ( isset( $this->theme_json->settings->_experimentalLayout ) ) {
+			if ( isset( $this->theme_json->settings ) ) {
 				return  $json_theme_json;
 			}
 		}


### PR DESCRIPTION
## What does this do/fix?

Add workaround for environments with enabled Basic Auth. When it is on `wp_remote_get` returns `Unauthorized` status. Due to that custom layout or styles won't work
Data retrieved with `file_get_contents` with absolute path provided. If it fails fallback with `wp_remote_get` will make another try

## QA

Links to relevant issues
- [Link to Issue](https://example.com)

Screenshots/video:
- [Link to Video](https://example.com)
