### PR TITLE
fix isset for basic auth call; bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://tri.be
 Tags: blocks, editor, alignment
 Requires at least: 6.0
 Tested up to: 6.5.2
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/block-editor-custom-alignments.php
+++ b/block-editor-custom-alignments.php
@@ -13,7 +13,7 @@
  * Plugin Name:       Block Editor Custom Alignments
  * Plugin URI:        https://https://github.com/moderntribe/block-editor-custom-alignments
  * Description:       Allows developers to add custom alignments to `theme.json` for use in the block editor.
- * Version:           1.1.0
+ * Version:           1.1.1
  * Author:            Modern Tribe
  * Author URI:        https://tri.be
  * License:           GPL-2.0+
@@ -54,7 +54,7 @@ class Block_Editor_Custom_Alignments {
 	public function __construct() {
 		global $pagenow;
 
-		$this->version      = '1.1.0';
+		$this->version      = '1.1.1';
 		$this->name         = 'block-editor-custom-alignments';
 		$this->base_url     = trailingslashit( plugin_dir_url( __FILE__ ) );
 		$this->theme_json   = $this->block_editor_custom_alignments_theme_json();
@@ -154,8 +154,8 @@ class Block_Editor_Custom_Alignments {
 		if ( $json_theme_content !== false ) {
 			$json_theme_json = $this->get_json_theme_json( $json_theme_content );
 
-			if ( isset( $this->theme_json->settings ) ) {
-				return  $json_theme_json;
+			if ( isset( $json_theme_json->settings ) ) {
+				return $json_theme_json;
 			}
 		}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "block-editor-custom-alignments",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "block-editor-custom-alignments",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
         "@csstools/postcss-global-data": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "block-editor-custom-alignments",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Allows developers to add custom alignments to `theme.json` for use in the block editor.",
   "author": "Modern Tribe <admin@tri.be>",
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION
## What does this do/fix?

- fixes issue where the `isset` call for determining if the `settings` object exists was using data that hadn't been set yet
- bumps plugin version
